### PR TITLE
Fix MDUI for CCV SPs

### DIFF
--- a/clarin-sp-metadata.xml
+++ b/clarin-sp-metadata.xml
@@ -3804,8 +3804,8 @@ x1TIfhRjlcLqYwvwFOhj5b/Ecr0B2QAwHeEhMq9or7o072A=</ds:X509Certificate>
         <mdui:UIInfo>
           <mdui:DisplayName xml:lang="en">ACDH-ÖAW Services for Digital Humanities</mdui:DisplayName>
           <mdui:DisplayName xml:lang="de">ACDH-ÖAW Dienste für Digitale Geisteswissenschaften</mdui:DisplayName>
-          <mdui:Description xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-AW) (primarily in the context of the CLARIN initiative).</mdui:Description>
-          <mdui:Description xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-AW) (primär im Rahmen der CLARIN-Initiative).</mdui:Description>
+          <mdui:Description xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW) (primarily in the context of the CLARIN initiative).</mdui:Description>
+          <mdui:Description xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW) (primär im Rahmen der CLARIN-Initiative).</mdui:Description>
           <mdui:InformationURL xml:lang="en">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:InformationURL xml:lang="de">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:PrivacyStatementURL xml:lang="en">https://arche.acdh.oeaw.ac.at/browser/privacy</mdui:PrivacyStatementURL>
@@ -3856,8 +3856,8 @@ rI8v6OTvibpLrg==
       <md:AttributeConsumingService index="1">
         <md:ServiceName xml:lang="en">ACDH-ÖAW Services for Digital Humanities</md:ServiceName>
         <md:ServiceName xml:lang="de">ACDH-ÖAW Dienste für Digitale Geisteswissenschaften</md:ServiceName>
-        <md:ServiceDescription xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-AW) (primarily in the context of the CLARIN initiative).</md:ServiceDescription>
-        <md:ServiceDescription xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-AW) (primär im Rahmen der CLARIN-Initiative).</md:ServiceDescription>
+        <md:ServiceDescription xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW) (primarily in the context of the CLARIN initiative).</md:ServiceDescription>
+        <md:ServiceDescription xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW) (primär im Rahmen der CLARIN-Initiative).</md:ServiceDescription>
         <md:RequestedAttribute isRequired="true" FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
         <md:RequestedAttribute isRequired="false" FriendlyName="eduPersonTargetedID" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.10" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
         <md:RequestedAttribute isRequired="false" FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
@@ -3870,8 +3870,8 @@ rI8v6OTvibpLrg==
     <md:Organization>
       <md:OrganizationName xml:lang="de">Österreichische Akademie der Wissenschaften</md:OrganizationName>
       <md:OrganizationName xml:lang="en">Austrian Academy of Sciences</md:OrganizationName>
-      <md:OrganizationDisplayName xml:lang="de">Österreichisches Zentrum für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-AW)</md:OrganizationDisplayName>
-      <md:OrganizationDisplayName xml:lang="en">Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-AW)</md:OrganizationDisplayName>
+      <md:OrganizationDisplayName xml:lang="de">Österreichisches Zentrum für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW)</md:OrganizationDisplayName>
+      <md:OrganizationDisplayName xml:lang="en">Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW)</md:OrganizationDisplayName>
       <md:OrganizationURL xml:lang="en">http://acdh.oeaw.ac.at/</md:OrganizationURL>
     </md:Organization>
     <md:ContactPerson contactType="technical">
@@ -3937,8 +3937,8 @@ rI8v6OTvibpLrg==
         <mdui:UIInfo>
           <mdui:DisplayName xml:lang="en">ACDH-ÖAW Services for Digital Humanities</mdui:DisplayName>
           <mdui:DisplayName xml:lang="de">ACDH-ÖAW Dienste für Digitale Geisteswissenschaften</mdui:DisplayName>
-          <mdui:Description xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-AW) (primarily in the context of the CLARIN initiative).</mdui:Description>
-          <mdui:Description xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-OeAW) (primär im Rahmen der CLARIN-Initiative).</mdui:Description>
+          <mdui:Description xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW) (primarily in the context of the CLARIN initiative).</mdui:Description>
+          <mdui:Description xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW) (primär im Rahmen der CLARIN-Initiative).</mdui:Description>
           <mdui:InformationURL xml:lang="en">https://www.oeaw.ac.at/acdh/tools/</mdui:InformationURL>
           <mdui:InformationURL xml:lang="de">https://www.oeaw.ac.at/acdh/tools/</mdui:InformationURL>
           <mdui:PrivacyStatementURL xml:lang="en">https://arche.acdh.oeaw.ac.at/browser/privacy</mdui:PrivacyStatementURL>
@@ -3989,8 +3989,8 @@ rI8v6OTvibpLrg==
       <md:AttributeConsumingService index="1">
         <md:ServiceName xml:lang="en">ACDH-ÖAW Services for Digital Humanities</md:ServiceName>
         <md:ServiceName xml:lang="de">ACDH-ÖAW Dienste für Digitale Geisteswissenschaften</md:ServiceName>
-        <md:ServiceDescription xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-AW) (primarily in the context of the CLARIN initiative).</md:ServiceDescription>
-        <md:ServiceDescription xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-AW) (primär im Rahmen der CLARIN-Initiative).</md:ServiceDescription>
+        <md:ServiceDescription xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW) (primarily in the context of the CLARIN initiative).</md:ServiceDescription>
+        <md:ServiceDescription xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW) (primär im Rahmen der CLARIN-Initiative).</md:ServiceDescription>
         <md:RequestedAttribute isRequired="true" FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
         <md:RequestedAttribute isRequired="false" FriendlyName="eduPersonTargetedID" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.10" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
         <md:RequestedAttribute isRequired="false" FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
@@ -4003,8 +4003,8 @@ rI8v6OTvibpLrg==
     <md:Organization>
       <md:OrganizationName xml:lang="de">Österreichische Akademie der Wissenschaften</md:OrganizationName>
       <md:OrganizationName xml:lang="en">Austrian Academy of Sciences</md:OrganizationName>
-      <md:OrganizationDisplayName xml:lang="de">Österreichisches Zentrum für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-OeAW)</md:OrganizationDisplayName>
-      <md:OrganizationDisplayName xml:lang="en">Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-OeAW)</md:OrganizationDisplayName>
+      <md:OrganizationDisplayName xml:lang="de">Österreichisches Zentrum für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW)</md:OrganizationDisplayName>
+      <md:OrganizationDisplayName xml:lang="en">Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW)</md:OrganizationDisplayName>
       <md:OrganizationURL xml:lang="en">http://acdh.oeaw.ac.at/</md:OrganizationURL>
     </md:Organization>
     <md:ContactPerson contactType="technical">
@@ -4070,8 +4070,8 @@ rI8v6OTvibpLrg==
         <mdui:UIInfo>
           <mdui:DisplayName xml:lang="en">ACDH-ÖAW Services for Digital Humanities</mdui:DisplayName>
           <mdui:DisplayName xml:lang="de">ACDH-ÖAW Dienste für Digitale Geisteswissenschaften</mdui:DisplayName>
-          <mdui:Description xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-AW) (primarily in the context of the CLARIN initiative).</mdui:Description>
-          <mdui:Description xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-AW) (primär im Rahmen der CLARIN-Initiative).</mdui:Description>
+          <mdui:Description xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW) (primarily in the context of the CLARIN initiative).</mdui:Description>
+          <mdui:Description xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW) (primär im Rahmen der CLARIN-Initiative).</mdui:Description>
           <mdui:InformationURL xml:lang="en">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:InformationURL xml:lang="de">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:PrivacyStatementURL xml:lang="en">https://arche.acdh.oeaw.ac.at/browser/privacy</mdui:PrivacyStatementURL>
@@ -4136,8 +4136,8 @@ rI8v6OTvibpLrg==
     <md:Organization>
       <md:OrganizationName xml:lang="de">Österreichische Akademie der Wissenschaften</md:OrganizationName>
       <md:OrganizationName xml:lang="en">Austrian Academy of Sciences</md:OrganizationName>
-      <md:OrganizationDisplayName xml:lang="de">Österreichisches Zentrum für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-AW)</md:OrganizationDisplayName>
-      <md:OrganizationDisplayName xml:lang="en">Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-AW)</md:OrganizationDisplayName>
+      <md:OrganizationDisplayName xml:lang="de">Österreichisches Zentrum für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW)</md:OrganizationDisplayName>
+      <md:OrganizationDisplayName xml:lang="en">Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW)</md:OrganizationDisplayName>
       <md:OrganizationURL xml:lang="en">http://acdh.oeaw.ac.at/</md:OrganizationURL>
     </md:Organization>
     <md:ContactPerson contactType="technical">
@@ -4203,8 +4203,8 @@ rI8v6OTvibpLrg==
         <mdui:UIInfo>
           <mdui:DisplayName xml:lang="en">ACDH-ÖAW Services for Digital Humanities</mdui:DisplayName>
           <mdui:DisplayName xml:lang="de">ACDH-ÖAW Dienste für Digitale Geisteswissenschaften</mdui:DisplayName>
-          <mdui:Description xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-AW) (primarily in the context of the CLARIN initiative).</mdui:Description>
-          <mdui:Description xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-AW) (primär im Rahmen der CLARIN-Initiative).</mdui:Description>
+          <mdui:Description xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW) (primarily in the context of the CLARIN initiative).</mdui:Description>
+          <mdui:Description xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW) (primär im Rahmen der CLARIN-Initiative).</mdui:Description>
           <mdui:InformationURL xml:lang="en">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:InformationURL xml:lang="de">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:PrivacyStatementURL xml:lang="en">https://arche.acdh.oeaw.ac.at/browser/privacy</mdui:PrivacyStatementURL>
@@ -4269,8 +4269,8 @@ rI8v6OTvibpLrg==
     <md:Organization>
       <md:OrganizationName xml:lang="de">Österreichische Akademie der Wissenschaften</md:OrganizationName>
       <md:OrganizationName xml:lang="en">Austrian Academy of Sciences</md:OrganizationName>
-      <md:OrganizationDisplayName xml:lang="de">Österreichisches Zentrum für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-AW)</md:OrganizationDisplayName>
-      <md:OrganizationDisplayName xml:lang="en">Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-AW)</md:OrganizationDisplayName>
+      <md:OrganizationDisplayName xml:lang="de">Österreichisches Zentrum für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW)</md:OrganizationDisplayName>
+      <md:OrganizationDisplayName xml:lang="en">Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW)</md:OrganizationDisplayName>
       <md:OrganizationURL xml:lang="en">http://acdh.oeaw.ac.at/</md:OrganizationURL>
     </md:Organization>
     <md:ContactPerson contactType="technical">
@@ -4336,8 +4336,8 @@ rI8v6OTvibpLrg==
         <mdui:UIInfo>
           <mdui:DisplayName xml:lang="en">ACDH-ÖAW Services for Digital Humanities</mdui:DisplayName>
           <mdui:DisplayName xml:lang="de">ACDH-ÖAW Dienste für Digitale Geisteswissenschaften</mdui:DisplayName>
-          <mdui:Description xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-AW) (primarily in the context of the CLARIN initiative).</mdui:Description>
-          <mdui:Description xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-AW) (primär im Rahmen der CLARIN-Initiative).</mdui:Description>
+          <mdui:Description xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW) (primarily in the context of the CLARIN initiative).</mdui:Description>
+          <mdui:Description xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW) (primär im Rahmen der CLARIN-Initiative).</mdui:Description>
           <mdui:InformationURL xml:lang="en">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:InformationURL xml:lang="de">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:PrivacyStatementURL xml:lang="en">https://arche.acdh.oeaw.ac.at/browser/privacy</mdui:PrivacyStatementURL>
@@ -4402,8 +4402,8 @@ rI8v6OTvibpLrg==
     <md:Organization>
       <md:OrganizationName xml:lang="de">Österreichische Akademie der Wissenschaften</md:OrganizationName>
       <md:OrganizationName xml:lang="en">Austrian Academy of Sciences</md:OrganizationName>
-      <md:OrganizationDisplayName xml:lang="de">Österreichisches Zentrum für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-AW)</md:OrganizationDisplayName>
-      <md:OrganizationDisplayName xml:lang="en">Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-AW)</md:OrganizationDisplayName>
+      <md:OrganizationDisplayName xml:lang="de">Österreichisches Zentrum für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW)</md:OrganizationDisplayName>
+      <md:OrganizationDisplayName xml:lang="en">Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW)</md:OrganizationDisplayName>
       <md:OrganizationURL xml:lang="en">http://acdh.oeaw.ac.at/</md:OrganizationURL>
     </md:Organization>
     <md:ContactPerson contactType="technical">
@@ -4469,8 +4469,8 @@ rI8v6OTvibpLrg==
         <mdui:UIInfo>
           <mdui:DisplayName xml:lang="en">ACDH-ÖAW Services for Digital Humanities</mdui:DisplayName>
           <mdui:DisplayName xml:lang="de">ACDH-ÖAW Dienste für Digitale Geisteswissenschaften</mdui:DisplayName>
-          <mdui:Description xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-AW) (primarily in the context of the CLARIN initiative).</mdui:Description>
-          <mdui:Description xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-OeAW) (primär im Rahmen der CLARIN-Initiative).</mdui:Description>
+          <mdui:Description xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW) (primarily in the context of the CLARIN initiative).</mdui:Description>
+          <mdui:Description xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW) (primär im Rahmen der CLARIN-Initiative).</mdui:Description>
           <mdui:InformationURL xml:lang="en">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:InformationURL xml:lang="de">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:PrivacyStatementURL xml:lang="en">https://arche.acdh.oeaw.ac.at/browser/privacy</mdui:PrivacyStatementURL>
@@ -4521,8 +4521,8 @@ rI8v6OTvibpLrg==
       <md:AttributeConsumingService index="1">
         <md:ServiceName xml:lang="en">ARCHE - A Resource Centre for HumanitiEs</md:ServiceName>
         <md:ServiceName xml:lang="de">ARCHE - A Resource Centre for HumanitiEs</md:ServiceName>        
-        <md:ServiceDescription xml:lang="en">A hosting service for research data provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-OeAW).</md:ServiceDescription>
-        <md:ServiceDescription xml:lang="de">Hosting Dienst für Forschungsdaten des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-OeAW).</md:ServiceDescription>
+        <md:ServiceDescription xml:lang="en">A hosting service for research data provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW).</md:ServiceDescription>
+        <md:ServiceDescription xml:lang="de">Hosting Dienst für Forschungsdaten des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW).</md:ServiceDescription>
         <md:RequestedAttribute isRequired="true" FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
         <md:RequestedAttribute isRequired="false" FriendlyName="eduPersonTargetedID" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.10" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
         <md:RequestedAttribute isRequired="false" FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
@@ -4535,8 +4535,8 @@ rI8v6OTvibpLrg==
     <md:Organization>
       <md:OrganizationName xml:lang="de">Österreichische Akademie der Wissenschaften</md:OrganizationName>
       <md:OrganizationName xml:lang="en">Austrian Academy of Sciences</md:OrganizationName>
-      <md:OrganizationDisplayName xml:lang="de">Österreichisches Zentrum für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-AW)</md:OrganizationDisplayName>
-      <md:OrganizationDisplayName xml:lang="en">Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-AW)</md:OrganizationDisplayName>
+      <md:OrganizationDisplayName xml:lang="de">Österreichisches Zentrum für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW)</md:OrganizationDisplayName>
+      <md:OrganizationDisplayName xml:lang="en">Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW)</md:OrganizationDisplayName>
       <md:OrganizationURL xml:lang="en">http://acdh.oeaw.ac.at/</md:OrganizationURL>
     </md:Organization>
     <md:ContactPerson contactType="technical">

--- a/clarin-sp-metadata.xml
+++ b/clarin-sp-metadata.xml
@@ -4068,10 +4068,10 @@ rI8v6OTvibpLrg==
         <init:RequestInitiator Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://redmine.acdh.oeaw.ac.at/Shibboleth.sso/Login"/>
         <idpdisc:DiscoveryResponse Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Location="https://redmine.acdh.oeaw.ac.at/Shibboleth.sso/Login" index="3"/>       
         <mdui:UIInfo>
-          <mdui:DisplayName xml:lang="en">ACDH-ÖAW Services for Digital Humanities</mdui:DisplayName>
-          <mdui:DisplayName xml:lang="de">ACDH-ÖAW Dienste für Digitale Geisteswissenschaften</mdui:DisplayName>
-          <mdui:Description xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW) (primarily in the context of the CLARIN initiative).</mdui:Description>
-          <mdui:Description xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW) (primär im Rahmen der CLARIN-Initiative).</mdui:Description>
+          <mdui:DisplayName xml:lang="en">redmine@acdh-oeaw</mdui:DisplayName>
+          <mdui:DisplayName xml:lang="de">redmine@acdh-oeaw</mdui:DisplayName>
+          <mdui:Description xml:lang="en">Project management system Redmine offered as service to the DH community</mdui:Description>
+          <mdui:Description xml:lang="de">Projektmanagementsystem Redmine als Service für die DH commmunity</mdui:Description>
           <mdui:InformationURL xml:lang="en">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:InformationURL xml:lang="de">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:PrivacyStatementURL xml:lang="en">https://arche.acdh.oeaw.ac.at/browser/privacy</mdui:PrivacyStatementURL>
@@ -4122,8 +4122,8 @@ rI8v6OTvibpLrg==
       <md:AttributeConsumingService index="1">
         <md:ServiceName xml:lang="en">redmine@acdh-oeaw</md:ServiceName>
         <md:ServiceName xml:lang="de">redmine@acdh-oeaw</md:ServiceName>
-        <md:ServiceDescription xml:lang="en">Project management system redmine offered as service to the DH community</md:ServiceDescription>
-        <md:ServiceDescription xml:lang="de">Projekt management system redmine als Service für dei DH commmunity</md:ServiceDescription>
+        <md:ServiceDescription xml:lang="en">Project management system Redmine offered as service to the DH community</md:ServiceDescription>
+        <md:ServiceDescription xml:lang="de">Projektmanagementsystem Redmine als Service für die DH commmunity</md:ServiceDescription>
         <md:RequestedAttribute isRequired="true" FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
         <md:RequestedAttribute isRequired="false" FriendlyName="eduPersonTargetedID" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.10" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
         <md:RequestedAttribute isRequired="false" FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
@@ -4201,10 +4201,10 @@ rI8v6OTvibpLrg==
         <init:RequestInitiator Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://teach.dariah.eu/Shibboleth.sso/Login"/>
         <idpdisc:DiscoveryResponse Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Location="https://teach.dariah.eu/Shibboleth.sso/Login" index="4"/>
         <mdui:UIInfo>
-          <mdui:DisplayName xml:lang="en">ACDH-ÖAW Services for Digital Humanities</mdui:DisplayName>
-          <mdui:DisplayName xml:lang="de">ACDH-ÖAW Dienste für Digitale Geisteswissenschaften</mdui:DisplayName>
-          <mdui:Description xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW) (primarily in the context of the CLARIN initiative).</mdui:Description>
-          <mdui:Description xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW) (primär im Rahmen der CLARIN-Initiative).</mdui:Description>
+          <mdui:DisplayName xml:lang="en">dariahTeach</mdui:DisplayName>
+          <mdui:DisplayName xml:lang="de">dariahTeach</mdui:DisplayName>
+          <mdui:Description xml:lang="en">Platform for teaching materials for the digital arts and humanities.</mdui:Description>
+          <mdui:Description xml:lang="de">e-Learning Plattform für Lernmaterialien für Digitale Geisteswissenschaften</mdui:Description>
           <mdui:InformationURL xml:lang="en">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:InformationURL xml:lang="de">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:PrivacyStatementURL xml:lang="en">https://arche.acdh.oeaw.ac.at/browser/privacy</mdui:PrivacyStatementURL>
@@ -4334,10 +4334,10 @@ rI8v6OTvibpLrg==
         <init:RequestInitiator Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://registries.clarin-dariah.eu/Shibboleth.sso/Login"/>
         <idpdisc:DiscoveryResponse Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Location="https://registries.clarin-dariah.eu/Shibboleth.sso/Login" index="5"/>
         <mdui:UIInfo>
-          <mdui:DisplayName xml:lang="en">ACDH-ÖAW Services for Digital Humanities</mdui:DisplayName>
-          <mdui:DisplayName xml:lang="de">ACDH-ÖAW Dienste für Digitale Geisteswissenschaften</mdui:DisplayName>
-          <mdui:Description xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW) (primarily in the context of the CLARIN initiative).</mdui:Description>
-          <mdui:Description xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW) (primär im Rahmen der CLARIN-Initiative).</mdui:Description>
+          <mdui:DisplayName xml:lang="en">DH course registry</mdui:DisplayName>
+          <mdui:DisplayName xml:lang="de">DH course registry</mdui:DisplayName>
+          <mdui:Description xml:lang="en">Registry of DH-related courses (study programs) across Europe jointly maintained by the research infrastructures CLARIN-ERIC and DARIAH-EU</mdui:Description>
+          <mdui:Description xml:lang="de">Registry von DH-relevanten Studienprogrammen und Kursen in Europa gemeinsam verwaltet von den Forschungsinfrastrukturen CLARIN-ERIC und DARIAH-EU</mdui:Description>
           <mdui:InformationURL xml:lang="en">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:InformationURL xml:lang="de">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:PrivacyStatementURL xml:lang="en">https://arche.acdh.oeaw.ac.at/browser/privacy</mdui:PrivacyStatementURL>
@@ -4467,10 +4467,10 @@ rI8v6OTvibpLrg==
         <init:RequestInitiator Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://arche.acdh.oeaw.ac.at/Shibboleth.sso/Login"/>
         <idpdisc:DiscoveryResponse Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Location="https://arche.acdh.oeaw.ac.at/Shibboleth.sso/Login" index="6"/>
         <mdui:UIInfo>
-          <mdui:DisplayName xml:lang="en">ACDH-ÖAW Services for Digital Humanities</mdui:DisplayName>
-          <mdui:DisplayName xml:lang="de">ACDH-ÖAW Dienste für Digitale Geisteswissenschaften</mdui:DisplayName>
-          <mdui:Description xml:lang="en">Various services provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW) (primarily in the context of the CLARIN initiative).</mdui:Description>
-          <mdui:Description xml:lang="de">Verschiedene Dienste des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW) (primär im Rahmen der CLARIN-Initiative).</mdui:Description>
+          <mdui:DisplayName xml:lang="en">ARCHE - A Resource Centre for HumanitiEs</mdui:DisplayName>
+          <mdui:DisplayName xml:lang="de">ARCHE - A Resource Centre for HumanitiEs</mdui:DisplayName>
+          <mdui:Description xml:lang="en">A hosting service for research data provided by the Austrian Centre for Digital Humanities of the Austrian Academy of Sciences (ACDH-ÖAW).</mdui:Description>
+          <mdui:Description xml:lang="de">Hosting Dienst für Forschungsdaten des österreichischen Zentrums für Digitale Geisteswissenschaften der Österreichischen Akademie der Wissenschaften (ACDH-ÖAW).</mdui:Description>
           <mdui:InformationURL xml:lang="en">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:InformationURL xml:lang="de">http://acdh.oeaw.ac.at/</mdui:InformationURL>
           <mdui:PrivacyStatementURL xml:lang="en">https://arche.acdh.oeaw.ac.at/browser/privacy</mdui:PrivacyStatementURL>


### PR DESCRIPTION
Fixes copy/paste errors ("AW" instead of "ÖAW) and copies the content of new, SP-specific `md:ServiceName` and `md:ServiceDescription` elements to their (seemingly forgotten) MDUI-equivalents.