### PR TITLE
add LAP metadata

### DIFF
--- a/clarin-sp-metadata.xml
+++ b/clarin-sp-metadata.xml
@@ -23,6 +23,78 @@
             registrationAuthority="https://www.clarin.eu/spf"> </mdrpi:RegistrationInfo>
     </Extensions>
 
+    <!-- UiO Language Analysis Portal (LAP) -->
+    <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://lap.clarino.uio.no/simplesaml/module.php/saml/sp/metadata.php/default-sp">
+      <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:1.1:protocol urn:oasis:names:tc:SAML:2.0:protocol">
+        <md:Extensions>
+          <mdui:UIInfo xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui">
+            <mdui:DisplayName xml:lang="en">LAP: UiO Language Analysis Portal (Production)</mdui:DisplayName>
+            <mdui:Description xml:lang="en">Ready-to-Run and State-of-the-Art Language Analysis Tools in the Cloud</mdui:Description>
+            <mdui:InformationURL xml:lang="en">http://www.mn.uio.no/ifi/english/research/projects/clarino/</mdui:InformationURL>
+            <mdui:PrivacyStatementURL xml:lang="en">http://www.mn.uio.no/ifi/english/research/projects/clarino/user/privacy/</mdui:PrivacyStatementURL>
+            <mdui:Logo width="45" height="25" xml:lang="en">http://svn.emmtee.net/lap/trunk/public/www/logo/lap.transparent.25x25.pngOB</mdui:Logo>
+          </mdui:UIInfo>
+        </md:Extensions>
+        <md:KeyDescriptor use="signing">
+          <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+              <ds:X509Certificate>MIIE/zCCA+egAwIBAgIRAJIQa4w218rFk4verorM7VswDQYJKoZIhvcNAQELBQAwZDELMAkGA1UEBhMCTkwxFjAUBgNVBAgTDU5vb3JkLUhvbGxhbmQxEjAQBgNVBAcTCUFtc3RlcmRhbTEPMA0GA1UEChMGVEVSRU5BMRgwFgYDVQQDEw9URVJFTkEgU1NMIENBIDIwHhcNMTUwNjMwMDAwMDAwWhcNMTgwNjI5MjM1OTU5WjA8MSEwHwYDVQQLExhEb21haW4gQ29udHJvbCBWYWxpZGF0ZWQxFzAVBgNVBAMTDmNsYXJpbm8udWlvLm5vMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzWtCRL9wf3nor/dUkG00Xg4jmr6nZX5qxOCHDX0rRJB8VWU52kfQyKWViv5BtcsnIweBqJ75sobprZuKcDILRf36F4i4D6lPcxFvDac1DA6smlfP+sMyf5ntfJkc6sMjgDQ/2CQKFvcwYlhJSXStR1Hc95+GRXK4ou30XXv6MaU98OR+laQuOqsQB6VBh60iRDXNrKhrePG3HJujn79VcLB4N79Tk5GV+BuqvZP8Mh+cTK6q/XN5EM13/CMXdPtng0Fh9RPJNBYgA/cmXHFdEM+/9HfdUOfyByeYEHOuKXUr/dLJQ7tYUds494qxCdkEckt0o92OxpRTztsvI+YcDQIDAQABo4IB0jCCAc4wHwYDVR0jBBgwFoAUW9CKHJoyW+C13ZZUG+GGKLD9tr0wHQYDVR0OBBYEFMUNIwQsUMuAUNhNsROf0SU9l2aZMA4GA1UdDwEB/wQEAwIFoDAMBgNVHRMBAf8EAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAiBgNVHSAEGzAZMA0GCysGAQQBsjEBAgIdMAgGBmeBDAECATA6BgNVHR8EMzAxMC+gLaArhilodHRwOi8vY3JsLnVzZXJ0cnVzdC5jb20vVEVSRU5BU1NMQ0EyLmNybDBsBggrBgEFBQcBAQRgMF4wNQYIKwYBBQUHMAKGKWh0dHA6Ly9jcnQudXNlcnRydXN0LmNvbS9URVJFTkFTU0xDQTIuY3J0MCUGCCsGAQUFBzABhhlodHRwOi8vb2NzcC51c2VydHJ1c3QuY29tMIGABgNVHREEeTB3gg5jbGFyaW5vLnVpby5ub4ISZWRkLmNsYXJpbm8udWlvLm5vghVnbG9zc2EuY2xhcmluby51aW8ubm+CEmxhcC5jbGFyaW5vLnVpby5ub4ISc3ZuLmNsYXJpbm8udWlvLm5vghJ3d3cuY2xhcmluby51aW8ubm8wDQYJKoZIhvcNAQELBQADggEBADHuVaZ2ymF0bhfypJB0w2XfTXTcO7wbkuRLcrvv+3BQgHGv5j5xTjK6AesSxXE0KCtpJnTrR8TEQFbLhuUs0m4VyHlW8DivkccYbSzGvTewkxWSuxUFQhBWKhfNX4bPV88w9aLog358lHQBiqwY+cJYW8+Y48w49noiZDTCY7Z8jMbVj8jTVqC6bMELBMeV4stgzkT/RBFc1rroBhDeyjElugiph5RUtjwP/H/tAlLO241jMtIfbzRV/CwF9aEfpe/fAj4PXAWnK+KYz3ZqG4Q9s3GRNQZQfuLoEilwGvLSfhmdDXHQdDlubsO6iCUOwH0YwVRHP2OY95WzeMuD+H8=</ds:X509Certificate>
+            </ds:X509Data>
+          </ds:KeyInfo>
+        </md:KeyDescriptor>
+        <md:KeyDescriptor use="encryption">
+          <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+              <ds:X509Certificate>MIIE/zCCA+egAwIBAgIRAJIQa4w218rFk4verorM7VswDQYJKoZIhvcNAQELBQAwZDELMAkGA1UEBhMCTkwxFjAUBgNVBAgTDU5vb3JkLUhvbGxhbmQxEjAQBgNVBAcTCUFtc3RlcmRhbTEPMA0GA1UEChMGVEVSRU5BMRgwFgYDVQQDEw9URVJFTkEgU1NMIENBIDIwHhcNMTUwNjMwMDAwMDAwWhcNMTgwNjI5MjM1OTU5WjA8MSEwHwYDVQQLExhEb21haW4gQ29udHJvbCBWYWxpZGF0ZWQxFzAVBgNVBAMTDmNsYXJpbm8udWlvLm5vMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzWtCRL9wf3nor/dUkG00Xg4jmr6nZX5qxOCHDX0rRJB8VWU52kfQyKWViv5BtcsnIweBqJ75sobprZuKcDILRf36F4i4D6lPcxFvDac1DA6smlfP+sMyf5ntfJkc6sMjgDQ/2CQKFvcwYlhJSXStR1Hc95+GRXK4ou30XXv6MaU98OR+laQuOqsQB6VBh60iRDXNrKhrePG3HJujn79VcLB4N79Tk5GV+BuqvZP8Mh+cTK6q/XN5EM13/CMXdPtng0Fh9RPJNBYgA/cmXHFdEM+/9HfdUOfyByeYEHOuKXUr/dLJQ7tYUds494qxCdkEckt0o92OxpRTztsvI+YcDQIDAQABo4IB0jCCAc4wHwYDVR0jBBgwFoAUW9CKHJoyW+C13ZZUG+GGKLD9tr0wHQYDVR0OBBYEFMUNIwQsUMuAUNhNsROf0SU9l2aZMA4GA1UdDwEB/wQEAwIFoDAMBgNVHRMBAf8EAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAiBgNVHSAEGzAZMA0GCysGAQQBsjEBAgIdMAgGBmeBDAECATA6BgNVHR8EMzAxMC+gLaArhilodHRwOi8vY3JsLnVzZXJ0cnVzdC5jb20vVEVSRU5BU1NMQ0EyLmNybDBsBggrBgEFBQcBAQRgMF4wNQYIKwYBBQUHMAKGKWh0dHA6Ly9jcnQudXNlcnRydXN0LmNvbS9URVJFTkFTU0xDQTIuY3J0MCUGCCsGAQUFBzABhhlodHRwOi8vb2NzcC51c2VydHJ1c3QuY29tMIGABgNVHREEeTB3gg5jbGFyaW5vLnVpby5ub4ISZWRkLmNsYXJpbm8udWlvLm5vghVnbG9zc2EuY2xhcmluby51aW8ubm+CEmxhcC5jbGFyaW5vLnVpby5ub4ISc3ZuLmNsYXJpbm8udWlvLm5vghJ3d3cuY2xhcmluby51aW8ubm8wDQYJKoZIhvcNAQELBQADggEBADHuVaZ2ymF0bhfypJB0w2XfTXTcO7wbkuRLcrvv+3BQgHGv5j5xTjK6AesSxXE0KCtpJnTrR8TEQFbLhuUs0m4VyHlW8DivkccYbSzGvTewkxWSuxUFQhBWKhfNX4bPV88w9aLog358lHQBiqwY+cJYW8+Y48w49noiZDTCY7Z8jMbVj8jTVqC6bMELBMeV4stgzkT/RBFc1rroBhDeyjElugiph5RUtjwP/H/tAlLO241jMtIfbzRV/CwF9aEfpe/fAj4PXAWnK+KYz3ZqG4Q9s3GRNQZQfuLoEilwGvLSfhmdDXHQdDlubsO6iCUOwH0YwVRHP2OY95WzeMuD+H8=</ds:X509Certificate>
+            </ds:X509Data>
+          </ds:KeyInfo>
+        </md:KeyDescriptor>
+        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://lap.clarino.uio.no/simplesaml/module.php/saml/sp/saml2-logout.php/default-sp"/>
+        <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://lap.clarino.uio.no/simplesaml/module.php/saml/sp/saml2-acs.php/default-sp" index="0"/>
+        <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:browser-post" Location="https://lap.clarino.uio.no/simplesaml/module.php/saml/sp/saml1-acs.php/default-sp" index="1"/>
+        <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://lap.clarino.uio.no/simplesaml/module.php/saml/sp/saml2-acs.php/default-sp" index="2"/>
+        <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:1.0:profiles:artifact-01" Location="https://lap.clarino.uio.no/simplesaml/module.php/saml/sp/saml1-acs.php/default-sp/artifact" index="3"/>
+        <md:AttributeConsumingService index="0">
+          <md:ServiceName xml:lang="en">LAP: UiO Language Analysis Portal (Production)</md:ServiceName>
+          <md:ServiceDescription xml:lang="en">Ready-to-Run and State-of-the-Art Language Analysis Tools in the Cloud</md:ServiceDescription>
+          <md:RequestedAttribute Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
+          <md:RequestedAttribute Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
+          <md:RequestedAttribute Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.10" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
+        </md:AttributeConsumingService>
+      </md:SPSSODescriptor>
+      <md:Organization>
+        <md:OrganizationName xml:lang="en">University of Oslo</md:OrganizationName>
+        <md:OrganizationDisplayName xml:lang="en">University of Oslo</md:OrganizationDisplayName>
+        <md:OrganizationURL xml:lang="en">http://www.uio.no</md:OrganizationURL>
+      </md:Organization>
+      <md:ContactPerson contactType="technical">
+        <md:GivenName>Stephan</md:GivenName>
+        <md:SurName>Oepen</md:SurName>
+        <md:EmailAddress>lap-developers@ifi.uio.no</md:EmailAddress>
+      </md:ContactPerson>
+      <md:ContactPerson contactType="administrative">
+        <md:Company>University of Oslo (Norway)</md:Company>
+        <md:GivenName>Stephan</md:GivenName>
+        <md:SurName>Oepen</md:SurName>
+        <md:EmailAddress>lap-developers@ifi.uio.no</md:EmailAddress>
+        <md:TelephoneNumber>+47-4546 6632</md:TelephoneNumber>
+      </md:ContactPerson>
+      <md:ContactPerson contactType="technical">
+        <md:Company>University of Oslo (Norway)</md:Company>
+        <md:GivenName>Stephan</md:GivenName>
+        <md:SurName>Oepen</md:SurName>
+        <md:EmailAddress>lap-developers@ifi.uio.no</md:EmailAddress>
+        <md:TelephoneNumber>+47-4546 6632</md:TelephoneNumber>
+      </md:ContactPerson>
+      <md:ContactPerson contactType="support">
+        <md:Company>University of Oslo (Norway)</md:Company>
+        <md:GivenName>Stephan</md:GivenName>
+        <md:SurName>Oepen</md:SurName>
+        <md:EmailAddress>lap-developers@ifi.uio.no</md:EmailAddress>
+        <md:TelephoneNumber>+47-4546 6632</md:TelephoneNumber>
+      </md:ContactPerson>
+    </md:EntityDescriptor>
+
     <!-- BBAW (via CLARIN) -->
     <md:EntityDescriptor
         xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"


### PR DESCRIPTION
hi,

we would like to enable authentication against the CLARIN IdP, hence would be grateful if you could pick up the metadata for our SP (the UiO Language Analysis Portal, built as part of the national CLARINO initiative).

with thanks in advance, oe
