### PR TITLE
RequestInitiator element added

### DIFF
--- a/metadata/authentication.clariah.nl%2FSaml2%2Fproxy_saml2_backend.xml.xml
+++ b/metadata/authentication.clariah.nl%2FSaml2%2Fproxy_saml2_backend.xml.xml
@@ -27,6 +27,8 @@
                        WantAssertionsSigned="true"
                        protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
       <md:Extensions>
+         <init:RequestInitiator Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init"
+                                Location="https://authentication.clariah.nl/Saml2/disco?workaround=true"/>
          <idpdisc:DiscoveryResponse Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
                                     Location="https://authentication.clariah.nl/Saml2/disco?workaround=true"
                                     index="1"/>

--- a/metadata/testauthentication.di.huc.knaw.nl%2FSaml2%2Fproxy_saml2_backend.xml.xml
+++ b/metadata/testauthentication.di.huc.knaw.nl%2FSaml2%2Fproxy_saml2_backend.xml.xml
@@ -27,7 +27,9 @@
                        WantAssertionsSigned="true"
                        protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
       <md:Extensions>
-         <idpdisc:DiscoveryResponse Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
+          <init:RequestInitiator Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init"
+                                 Location="https://testauthentication.di.huc.knaw.nl/Saml2/disco?workaround=true"/>
+          <idpdisc:DiscoveryResponse Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
                                     Location="https://testauthentication.di.huc.knaw.nl/Saml2/disco?workaround=true"
                                     index="1"/>
          <mdui:UIInfo>


### PR DESCRIPTION
to https://authentication.clariah.nl/Saml2/proxy_saml2_backend.xml and https://testauthentication.di.huc.knaw.nl/Saml2/proxy_saml2_backend.xml.
In all cases which I saw the Location of RequestInitiator was identical to the Location of DiscoveryResponse, so I used this as well. Hopefully this is correct.