### PR TITLE
Update ka3.uni-koeln.de.xml

### DIFF
--- a/metadata/ka3.uni-koeln.de.xml
+++ b/metadata/ka3.uni-koeln.de.xml
@@ -106,7 +106,6 @@
                         PhFnxAIYf76Cxc64nauJTs5ZUZpy0DJ47gsgf4m4jh+Q16WgIlGqrEpp0JsiO0hO
                         0TTFsk5H2Rmv4SgMWSMRl4eMU8U1K9H20vOfHBoFElcKPaXSsWvjPcUcH/WJzeoC
                         77AALUF1ntrSftLrQaft5VwgE7cpfEw4tiDkErT81hLSA21ENsxq4REcVWMzG+p/
-
                     </ds:X509Certificate>
                 </ds:X509Data>
             </ds:KeyInfo>

--- a/metadata/ka3.uni-koeln.de.xml
+++ b/metadata/ka3.uni-koeln.de.xml
@@ -106,6 +106,7 @@
                         PhFnxAIYf76Cxc64nauJTs5ZUZpy0DJ47gsgf4m4jh+Q16WgIlGqrEpp0JsiO0hO
                         0TTFsk5H2Rmv4SgMWSMRl4eMU8U1K9H20vOfHBoFElcKPaXSsWvjPcUcH/WJzeoC
                         77AALUF1ntrSftLrQaft5VwgE7cpfEw4tiDkErT81hLSA21ENsxq4REcVWMzG+p/
+
                     </ds:X509Certificate>
                 </ds:X509Data>
             </ds:KeyInfo>

--- a/metadata/ka3.uni-koeln.de.xml
+++ b/metadata/ka3.uni-koeln.de.xml
@@ -1,177 +1,215 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
-                     xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
-                     xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
-                     xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
-                     xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init"
-                     xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
-                     xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
-                     xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
-                     xmlns:remd="http://refeds.org/metadata"
-                     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
-                     xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
-                     xmlns:shibmd="urn:mace:shibboleth:metadata:1.0"
-                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     entityID="https://ka3.uni-koeln.de">
-   <md:Extensions>
-      <mdattr:EntityAttributes>
-         <saml:Attribute NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
-                         Name="http://macedir.org/entity-category">
-            <saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
-         </saml:Attribute>
-         <saml:Attribute Name="http://macedir.org/entity-category"
-                         NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
-            <saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
-         </saml:Attribute>
-         <saml:Attribute Name="http://macedir.org/entity-category"
-                         NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
-            <saml:AttributeValue>http://clarin.eu/category/clarin-member</saml:AttributeValue>
-         </saml:Attribute>
-      </mdattr:EntityAttributes>
-   </md:Extensions>
-   <md:SPSSODescriptor AuthnRequestsSigned="true"
-                       WantAssertionsSigned="true"
-                       protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
-      <md:Extensions>
-         <init:RequestInitiator Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init"
-                                Location="https://ka3.uni-koeln.de/saml/login"/>
-         <idpdisco:DiscoveryResponse xmlns:idpdisco="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
-                                     Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
-                                     Location="https://ka3.uni-koeln.de/saml/login"
-                                     index="0"/>
-         <mdui:UIInfo>
-            <mdui:DisplayName xml:lang="de">KA³ Köln</mdui:DisplayName>
-            <mdui:DisplayName xml:lang="en">KA³ Cologne</mdui:DisplayName>
-            <mdui:Description xml:lang="de">Kölner Zentrum Archivierung und Analyse von AV-Daten</mdui:Description>
-            <mdui:Description xml:lang="en">Cologne Center Archiving and Analysis of AV-Data</mdui:Description>
-            <mdui:InformationURL xml:lang="de">https://ka3.uni-koeln.de</mdui:InformationURL>
-            <mdui:InformationURL xml:lang="en">https://ka3.uni-koeln.de</mdui:InformationURL>
-            <mdui:Logo width="300" height="170">https://ka3.uni-koeln.de/static/uco.png</mdui:Logo>
-            <mdui:PrivacyStatementURL xml:lang="en">https://ka3.uni-koeln.de/home/privacyStatement</mdui:PrivacyStatementURL>
-         </mdui:UIInfo>
-      </md:Extensions>
-      <md:KeyDescriptor>
-         <ds:KeyInfo>
-            <ds:X509Data>
-               <ds:X509Certificate>MIIJejCCCGKgAwIBAgIMH9WMQ2Tna5pZoHu8MA0GCSqGSIb3DQEBCwUAMIGNMQsw
-    CQYDVQQGEwJERTFFMEMGA1UECgw8VmVyZWluIHp1ciBGb2VyZGVydW5nIGVpbmVz
-    IERldXRzY2hlbiBGb3JzY2h1bmdzbmV0emVzIGUuIFYuMRAwDgYDVQQLDAdERk4t
-    UEtJMSUwIwYDVQQDDBxERk4tVmVyZWluIEdsb2JhbCBJc3N1aW5nIENBMB4XDTE4
-    MTAwNDEyNTkzNFoXDTIxMDEwNTEyNTkzNFowgZkxCzAJBgNVBAYTAkRFMRwwGgYD
-    VQQIDBNOb3JkcmhlaW4tV2VzdGZhbGVuMQ4wDAYDVQQHDAVLb2VsbjEeMBwGA1UE
-    CgwVVW5pdmVyc2l0YWV0IHp1IEtvZWxuMSEwHwYDVQQLDBhSZWdpb25hbGVzIFJl
-    Y2hlbnplbnRydW0xGTAXBgNVBAMMEGthMy51bmkta29lbG4uZGUwggEiMA0GCSqG
-    SIb3DQEBAQUAA4IBDwAwggEKAoIBAQCy2iB2jcTF4UOfxoALcJWjXFZERUvm5I2I
-    XaPrHNhphWHJ8kizVSWV5XmDENq0Xph/kGqpmsr/VJz/2qOeBGm7LsH1abK/4Ppr
-    S+OFyWweAStcYhXebE6XqvBHF0qE+qd84SYkKLDI7+vFPdfXl69BE1oMHoOtKXfp
-    hU/tUyIHkCYhRxzVaipWGwU7ZDIuc/nTcaM5jn7sYcbdHpm1GPDW3tL5+un9eHNe
-    LVEL61RNgOtU2mkn75C5mtGyi+Cc4JamuxOz0nXyNMNhqr3P3VYHiLLiEf5e2Jrx
-    qJW8NFQST+25kvaBs9hS+qgCCZwrowEMPOU+sm0ToUDVZWESZYcdAgMBAAGjggXK
-    MIIFxjBZBgNVHSAEUjBQMAgGBmeBDAECAjANBgsrBgEEAYGtIYIsHjAPBg0rBgEE
-    AYGtIYIsAQEEMBEGDysGAQQBga0hgiwBAQQDCDARBg8rBgEEAYGtIYIsAgEEAwgw
-    CQYDVR0TBAIwADAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwIG
-    CCsGAQUFBwMBMB0GA1UdDgQWBBRmgcxsQfno+I29pFl6gpuMgO7x5TAfBgNVHSME
-    GDAWgBRrOpiL+fJTidrgrbIyHgkf6Ko7dDAbBgNVHREEFDASghBrYTMudW5pLWtv
-    ZWxuLmRlMIGNBgNVHR8EgYUwgYIwP6A9oDuGOWh0dHA6Ly9jZHAxLnBjYS5kZm4u
-    ZGUvZGZuLWNhLWdsb2JhbC1nMi9wdWIvY3JsL2NhY3JsLmNybDA/oD2gO4Y5aHR0
-    cDovL2NkcDIucGNhLmRmbi5kZS9kZm4tY2EtZ2xvYmFsLWcyL3B1Yi9jcmwvY2Fj
-    cmwuY3JsMIHbBggrBgEFBQcBAQSBzjCByzAzBggrBgEFBQcwAYYnaHR0cDovL29j
-    c3AucGNhLmRmbi5kZS9PQ1NQLVNlcnZlci9PQ1NQMEkGCCsGAQUFBzAChj1odHRw
-    Oi8vY2RwMS5wY2EuZGZuLmRlL2Rmbi1jYS1nbG9iYWwtZzIvcHViL2NhY2VydC9j
-    YWNlcnQuY3J0MEkGCCsGAQUFBzAChj1odHRwOi8vY2RwMi5wY2EuZGZuLmRlL2Rm
-    bi1jYS1nbG9iYWwtZzIvcHViL2NhY2VydC9jYWNlcnQuY3J0MIIDYgYKKwYBBAHW
-    eQIEAgSCA1IEggNOA0wAdwBvU3asMfAxGdiZAKRRFf93FRwR2QLBACkGjbIImjfZ
-    EwAAAWY/KaHEAAAEAwBIMEYCIQC+WXuUv/HZzg/QivcQr9dPzjejTs/sl9AnyVyc
-    onrr2wIhAPwCKx17NBAfCuQWmtB6CPSyP8FHsegRyzJYBKngvUtAAHYAVYHUwhaQ
-    NgFK6gubVzxT8MDkOHhwJQgXL6OqHQcT0wwAAAFmPymiyQAABAMARzBFAiEAvyN7
-    OtmuibhizOwRIrcOGO0wmIRR9YglXbraxItlidICICY9KcMYDMjaVgYn6vXlhDry
-    NQs1j2uzq/YAYqX0XSfkAHcAqucLfzy41WbIbC8Wl5yfRF9pqw60U1WJsvd6AwEE
-    880AAAFmPymhwAAABAMASDBGAiEA3/VxaAQggYo6CrKljOzJRaXukHYsS/ZiGQoj
-    VvkqfsgCIQDsa9sO5T9ycbIYSxcpF3G2fJNcu8sFXCNUBISnyDn9AgB2AO5Lvbd1
-    zmC64UJpH6vhnmajD35fsHLYgwDEe4l6qP3LAAABZj8podMAAAQDAEcwRQIgWYeX
-    gb4AW/Vg0kjLGtS8LRLIuSKdWFQmZJV7u6Q4KR8CIQCvrtfspUAZFA9EQc/8Qw1Z
-    M8PGmq1ZZKeF6aHsPiFlxgB2ALvZ37wfinG1k5Qjl6qSe0c4V5UKq1LoGpCWZDaO
-    HtGFAAABZj8ppA0AAAQDAEcwRQIhAMfcgWB93eaMi6d30F9NYl9v4CMRlrPtTmId
-    Pnztj2fIAiAVICiR+ayDNMJp/nIZyh1GswCP87PuU4Gt0vpXwBenFwB3AKS5CZC0
-    GFgUh7sTosxncAo8NZgE+RvfuON3zQ7IDdwQAAABZj8ppCMAAAQDAEgwRgIhAKh6
-    jXv5xbhC404jhpR0RC0Dwyh/sDMDPJLRIHrYEPOVAiEAvbfbMqWiMOMFvW18xm26
-    RYMF+KISS/UFji9ggRqIvYkAdwBElGUusO7Or8RAB9io/ijA2uaCvtjLMbU/0zOW
-    tbaBqAAAAWY/KaZxAAAEAwBIMEYCIQCyw2iozuSxmVZErAfRAEH07Um8FVBhRAna
-    XZlZjuN82AIhAKh7Y9TxW9/xQ1zhjJQUUG36LHIYMnX7QM/sGCUxx94EMA0GCSqG
-    SIb3DQEBCwUAA4IBAQAoDmtOcQemnI0J1MdT2uOd6vlJwTcIK4DW1IRg9RcyjJmF
-    aH54xNsB7z7EvHJETVO/XLJtaJ3I5XC11+yeR9cFbcDn8IlnYWaMmEkzxja9uWuG
-    VUzk9KOYGff3igXjDsNfCUxVQd9R5Hq2hR2B1b9KDoasWAC2/UrxBqzJjoqURe94
-    O9kKUjH3pkzJAzUDBQD8lk/DKuwJplv5Cc86eNeiRt0CoZhSLwotElv3zLMP4dsj
-    zLGoWJjcVz6xYJoXWnxkNoVi39n62UCbYDYCSJfU2V7nY7Kwxqr9emN7dXHRAgNr
-    43+kpCoOrBZsmRoM4j7s6kyuy1VtaoxoCN4BybrF
-                        </ds:X509Certificate>
-            </ds:X509Data>
-         </ds:KeyInfo>
-      </md:KeyDescriptor>
-      <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-                              Location="https://ka3.uni-koeln.de/saml/SingleLogout"/>
-      <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
-                              Location="https://ka3.uni-koeln.de/saml/SingleLogout"/>
-      <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
-                              Location="https://ka3.uni-koeln.de/saml/SingleLogout"/>
-      <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-      <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-      <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
-      <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-                                   Location="https://ka3.uni-koeln.de/saml/SSO"
-                                   index="0"
-                                   isDefault="true"/>
-      <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS"
-                                   Location="https://ka3.uni-koeln.de/saml/SSO"
-                                   index="1"/>
-      <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact"
-                                   Location="https://ka3.uni-koeln.de/saml/SSO"
-                                   index="2"/>
-      <md:AttributeConsumingService index="1">
-         <md:ServiceName xml:lang="de">KA³</md:ServiceName>
-         <md:ServiceName xml:lang="en">KA³</md:ServiceName>
-         <md:ServiceDescription xml:lang="de">Kölner Zentrum Archivierung und Analyse von AV-Daten</md:ServiceDescription>
-         <md:ServiceDescription xml:lang="en">Cologne Center Archiving and Analysis of AV-Data</md:ServiceDescription>
-         <md:RequestedAttribute FriendlyName="eduPersonPrincipalName"
-                                Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6"
-                                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
-                                isRequired="true"/>
-         <md:RequestedAttribute FriendlyName="cn"
-                                Name="urn:oid:2.5.4.3"
-                                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
-                                isRequired="true"/>
-         <md:RequestedAttribute FriendlyName="mail"
-                                Name="urn:oid:0.9.2342.19200300.100.1.3"
-                                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
-                                isRequired="true"/>
-      </md:AttributeConsumingService>
-   </md:SPSSODescriptor>
-   <md:Organization>
-      <md:OrganizationName xml:lang="de">RRZK</md:OrganizationName>
-      <md:OrganizationName xml:lang="en">RRZK</md:OrganizationName>
-      <md:OrganizationDisplayName xml:lang="de">Regionales Rechenzentrum der Universität zu Köln (RRZK)</md:OrganizationDisplayName>
-      <md:OrganizationDisplayName xml:lang="en">Regional Computing Centre, University of Cologne (RRZK)</md:OrganizationDisplayName>
-      <md:OrganizationURL xml:lang="de">https://rrzk.uni-koeln.de</md:OrganizationURL>
-      <md:OrganizationURL xml:lang="en">https://rrzk.uni-koeln.de</md:OrganizationURL>
-   </md:Organization>
-   <md:ContactPerson contactType="technical">
-      <md:GivenName>Jochen</md:GivenName>
-      <md:SurName>Graf</md:SurName>
-      <md:EmailAddress>mailto:jochen.graf@uni-koeln.de</md:EmailAddress>
-   </md:ContactPerson>
-   <md:ContactPerson contactType="support">
-      <md:GivenName>Diensteentwicklung</md:GivenName>
-      <md:SurName>RRZK</md:SurName>
-      <md:EmailAddress>mailto:diensteentwicklung-rrzk@uni-koeln.de</md:EmailAddress>
-   </md:ContactPerson>
-   <md:ContactPerson contactType="administrative">
-      <md:GivenName>Beate</md:GivenName>
-      <md:SurName>Schlesiona</md:SurName>
-      <md:EmailAddress>mailto:bschlesi@uni-koeln.de</md:EmailAddress>
-   </md:ContactPerson>
-   <md:ContactPerson contactType="other"
-                     remd:contactType="http://refeds.org/metadata/contactType/security">
-      <md:GivenName>Diensteentwicklung</md:GivenName>
-      <md:EmailAddress>mailto:diensteentwicklung-rrzk@uni-koeln.de</md:EmailAddress>
-   </md:ContactPerson>
+<?xml version="1.0"?>
+<md:EntityDescriptor
+        xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+        entityID="https://ka3.uni-koeln.de">
+    <md:Extensions>
+        <mdattr:EntityAttributes
+                xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute">
+            <saml:Attribute
+                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                    NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+                    Name="http://macedir.org/entity-category">
+                <saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+            </saml:Attribute>
+            <saml:Attribute
+                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                    Name="http://macedir.org/entity-category"
+                    NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                <saml:AttributeValue>http://refeds.org/category/research-and-scholarship</saml:AttributeValue>
+            </saml:Attribute>
+            <saml:Attribute
+                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                    Name="http://macedir.org/entity-category"
+                    NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+                <saml:AttributeValue>http://clarin.eu/category/clarin-member</saml:AttributeValue>
+            </saml:Attribute>
+        </mdattr:EntityAttributes>
+    </md:Extensions>
+    <md:SPSSODescriptor
+            AuthnRequestsSigned="true"
+            WantAssertionsSigned="true"
+            protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <md:Extensions>
+            <init:RequestInitiator
+                    xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init"
+                    Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init"
+                    Location="https://ka3.uni-koeln.de/saml/login"/>
+            <idpdisco:DiscoveryResponse
+                    xmlns:idpdisco="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
+                    Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
+                    Location="https://ka3.uni-koeln.de/saml/login" index="0"/>
+            <mdui:UIInfo
+                    xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui">
+                <mdui:DisplayName
+                        xml:lang="de">KA&#xB3; K&#xF6;ln</mdui:DisplayName>
+                <mdui:DisplayName
+                        xml:lang="en">KA&#xB3; Cologne</mdui:DisplayName>
+                <mdui:Description
+                        xml:lang="de">K&#xF6;lner Zentrum Archivierung und Analyse von AV-Daten</mdui:Description>
+                <mdui:Description
+                        xml:lang="en">Cologne Center Archiving and Analysis of AV-Data</mdui:Description>
+                <mdui:InformationURL
+                        xml:lang="de">https://ka3.uni-koeln.de</mdui:InformationURL>
+                <mdui:InformationURL
+                        xml:lang="en">https://ka3.uni-koeln.de</mdui:InformationURL>
+                <mdui:Logo
+                        width="300"
+                        height="170">https://ka3.uni-koeln.de/static/uco.png</mdui:Logo>
+                <mdui:PrivacyStatementURL
+                        xml:lang="en">https://ka3.uni-koeln.de/home/privacyStatement</mdui:PrivacyStatementURL>
+            </mdui:UIInfo>
+        </md:Extensions>
+        <md:KeyDescriptor>
+            <ds:KeyInfo
+                    xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                <ds:X509Data>
+                    <ds:X509Certificate>MIIIDDCCBvSgAwIBAgIMI+8HirnW2calTyweMA0GCSqGSIb3DQEBCwUAMIGNMQsw
+                        CQYDVQQGEwJERTFFMEMGA1UECgw8VmVyZWluIHp1ciBGb2VyZGVydW5nIGVpbmVz
+                        IERldXRzY2hlbiBGb3JzY2h1bmdzbmV0emVzIGUuIFYuMRAwDgYDVQQLDAdERk4t
+                        UEtJMSUwIwYDVQQDDBxERk4tVmVyZWluIEdsb2JhbCBJc3N1aW5nIENBMB4XDTIw
+                        MTIwODE0MTMxOFoXDTIyMDEwOTE0MTMxOFowgZkxCzAJBgNVBAYTAkRFMRwwGgYD
+                        VQQIDBNOb3JkcmhlaW4tV2VzdGZhbGVuMQ4wDAYDVQQHDAVLb2VsbjEeMBwGA1UE
+                        CgwVVW5pdmVyc2l0YWV0IHp1IEtvZWxuMSEwHwYDVQQLDBhSZWdpb25hbGVzIFJl
+                        Y2hlbnplbnRydW0xGTAXBgNVBAMMEGthMy51bmkta29lbG4uZGUwggEiMA0GCSqG
+                        SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDeBgnX41J4ozykKKcP0OqepT0L4h9fOmWl
+                        h24ZNcfVgp4z+8qUDlSYZLd1cyon/G+WV0SSmyvCEhzygEXNjPvObftBliKVIKRO
+                        XKK9rpWkwkeVJnSX/Hq4czQToQ3v5wsC3wleOQH0Z1okrTm4/ZH4BWOoUrsTu+VF
+                        qgoutSWZr9JG1J/fMryNTMIvBnKQEms64otWoUYaXgKxwYLC8XjeGiSgUK5XbwhV
+                        7GMqaD7oSbN/CyHH8dQ3nFTXy004y/ydg//IRDAp7zznDMFUdokAv5QcUvA7imiV
+                        rRxmFCMQGWkXSZnCgeqm12BQf4Ro/SQ/um16MZihwzsC2wR+J55JAgMBAAGjggRc
+                        MIIEWDBXBgNVHSAEUDBOMAgGBmeBDAECAjANBgsrBgEEAYGtIYIsHjAPBg0rBgEE
+                        AYGtIYIsAQEEMBAGDisGAQQBga0hgiwBAQQIMBAGDisGAQQBga0hgiwCAQQIMAkG
+                        A1UdEwQCMAAwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggr
+                        BgEFBQcDATAdBgNVHQ4EFgQUVSzq9ZBUD2qU6+MATe9LOwUPimowHwYDVR0jBBgw
+                        FoAUazqYi/nyU4na4K2yMh4JH+iqO3QwGwYDVR0RBBQwEoIQa2EzLnVuaS1rb2Vs
+                        bi5kZTCBjQYDVR0fBIGFMIGCMD+gPaA7hjlodHRwOi8vY2RwMS5wY2EuZGZuLmRl
+                        L2Rmbi1jYS1nbG9iYWwtZzIvcHViL2NybC9jYWNybC5jcmwwP6A9oDuGOWh0dHA6
+                        Ly9jZHAyLnBjYS5kZm4uZGUvZGZuLWNhLWdsb2JhbC1nMi9wdWIvY3JsL2NhY3Js
+                        LmNybDCB2wYIKwYBBQUHAQEEgc4wgcswMwYIKwYBBQUHMAGGJ2h0dHA6Ly9vY3Nw
+                        LnBjYS5kZm4uZGUvT0NTUC1TZXJ2ZXIvT0NTUDBJBggrBgEFBQcwAoY9aHR0cDov
+                        L2NkcDEucGNhLmRmbi5kZS9kZm4tY2EtZ2xvYmFsLWcyL3B1Yi9jYWNlcnQvY2Fj
+                        ZXJ0LmNydDBJBggrBgEFBQcwAoY9aHR0cDovL2NkcDIucGNhLmRmbi5kZS9kZm4t
+                        Y2EtZ2xvYmFsLWcyL3B1Yi9jYWNlcnQvY2FjZXJ0LmNydDCCAfYGCisGAQQB1nkC
+                        BAIEggHmBIIB4gHgAHYARqVV63X6kSAwtaKJafTzfREsQXS+/Um4havy/HD+bUcA
+                        AAF2QrMXUgAABAMARzBFAiBDEnPzNjnUV2+06BCMe48GgLMv07jcjiJ5WM8k+X/5
+                        gQIhAJuokRbkxVMtIdyIh7OHjhO02EXTJekx47llmucXuBbyAHYAKXm+8J45OSHw
+                        VnOfY6V35b5XfZxgCvj5TV0mXCVdx4QAAAF2QrMcVAAABAMARzBFAiEAtCgMAja8
+                        6wMHnEJs5cSd3Eh0GKDdezpiitim4b6skE4CIBrwsXxMeS9STN9UV7/sB6y7Jo8b
+                        7USn/zxFaJLFlqrRAHUAb1N2rDHwMRnYmQCkURX/dxUcEdkCwQApBo2yCJo32RMA
+                        AAF2QrMX+AAABAMARjBEAiAn98wGQ9mflHqL8epG+tQ+9NMSbsn9Z3HfjelIOufz
+                        FgIgDV3UoXmsw1c1B/lsQT67AjH9kW0Ab76e08PDtlCfyEIAdwBVgdTCFpA2AUrq
+                        C5tXPFPwwOQ4eHAlCBcvo6odBxPTDAAAAXZCsxkHAAAEAwBIMEYCIQCNqwvLMv93
+                        PF6DBWPgiw4DTY3NlQS4jaCQUu7V1Tn7OAIhAMnLgdBbESFVCjAVJPb56euF73SL
+                        pfhQYu0FAI/l2mJnMA0GCSqGSIb3DQEBCwUAA4IBAQAsmFHrhOKVPwJhBcIFznyx
+                        vLF8vSLVURJSlgZwm9CD3K16w0++375IpmXEFYX818Cy1c/fiJ6tD/PInC76NEjg
+                        vqW5ujwkx11ZOI2pomEzjOmpq21GfV3qjaAszpo09iSYwksmIroGK+NzhfB4MYi0
+                        PhFnxAIYf76Cxc64nauJTs5ZUZpy0DJ47gsgf4m4jh+Q16WgIlGqrEpp0JsiO0hO
+                        0TTFsk5H2Rmv4SgMWSMRl4eMU8U1K9H20vOfHBoFElcKPaXSsWvjPcUcH/WJzeoC
+                        77AALUF1ntrSftLrQaft5VwgE7cpfEw4tiDkErT81hLSA21ENsxq4REcVWMzG+p/
+
+                    </ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </md:KeyDescriptor>
+        <md:SingleLogoutService
+                Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                Location="https://ka3.uni-koeln.de/saml/SingleLogout"/>
+        <md:SingleLogoutService
+                Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+                Location="https://ka3.uni-koeln.de/saml/SingleLogout"/>
+        <md:SingleLogoutService
+                Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP"
+                Location="https://ka3.uni-koeln.de/saml/SingleLogout"/>
+        <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+        <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+        <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
+        <md:AssertionConsumerService
+                Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                Location="https://ka3.uni-koeln.de/saml/SSO"
+                index="0"
+                isDefault="true"/>
+        <md:AssertionConsumerService
+                Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS"
+                Location="https://ka3.uni-koeln.de/saml/SSO"
+                index="1"/>
+        <md:AssertionConsumerService
+                Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact"
+                Location="https://ka3.uni-koeln.de/saml/SSO"
+                index="2"/>
+        <md:AttributeConsumingService
+                index="1">
+            <md:ServiceName
+                    xml:lang="de">KA&#xB3;</md:ServiceName>
+            <md:ServiceName
+                    xml:lang="en">KA&#xB3;</md:ServiceName>
+            <md:ServiceDescription
+                    xml:lang="de">K&#xF6;lner Zentrum Archivierung und Analyse von AV-Daten</md:ServiceDescription>
+            <md:ServiceDescription
+                    xml:lang="en">Cologne Center Archiving and Analysis of AV-Data</md:ServiceDescription>
+            <md:RequestedAttribute
+                    FriendlyName="eduPersonPrincipalName"
+                    Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6"
+                    NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+                    isRequired="true"/>
+            <md:RequestedAttribute
+                    FriendlyName="cn"
+                    Name="urn:oid:2.5.4.3"
+                    NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+                    isRequired="false"/>
+            <md:RequestedAttribute
+                    FriendlyName="displayName"
+                    Name="urn:oid:2.16.840.1.113730.3.1.241"
+                    NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+                    isRequired="false"/>
+            <md:RequestedAttribute
+                    FriendlyName="mail"
+                    Name="urn:oid:0.9.2342.19200300.100.1.3"
+                    NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+                    isRequired="false"/>
+            <md:RequestedAttribute
+                    FriendlyName="email"
+                    Name="urn:oid:0.9.2342.19200300.100.1.3"
+                    NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+                    isRequired="false"/>
+        </md:AttributeConsumingService>
+    </md:SPSSODescriptor>
+    <md:Organization>
+        <md:OrganizationName
+                xml:lang="de">RRZK</md:OrganizationName>
+        <md:OrganizationName
+                xml:lang="en">RRZK</md:OrganizationName>
+        <md:OrganizationDisplayName
+                xml:lang="de">Regionales Rechenzentrum der Universit&#xE4;t zu K&#xF6;ln (RRZK)</md:OrganizationDisplayName>
+        <md:OrganizationDisplayName
+                xml:lang="en">Regional Computing Centre, University of Cologne (RRZK)</md:OrganizationDisplayName>
+        <md:OrganizationURL
+                xml:lang="de">https://rrzk.uni-koeln.de</md:OrganizationURL>
+        <md:OrganizationURL
+                xml:lang="en">https://rrzk.uni-koeln.de</md:OrganizationURL>
+    </md:Organization>
+    <md:ContactPerson
+            contactType="technical">
+        <md:GivenName>Jochen</md:GivenName>
+        <md:SurName>Graf</md:SurName>
+        <md:EmailAddress>mailto:jochen.graf@uni-koeln.de</md:EmailAddress>
+    </md:ContactPerson>
+    <md:ContactPerson
+            contactType="support">
+        <md:GivenName>Diensteentwicklung</md:GivenName>
+        <md:SurName>RRZK</md:SurName>
+        <md:EmailAddress>mailto:diensteentwicklung-rrzk@uni-koeln.de</md:EmailAddress>
+    </md:ContactPerson>
+    <md:ContactPerson
+            contactType="administrative">
+        <md:GivenName>Beate</md:GivenName>
+        <md:SurName>Schlesiona</md:SurName>
+        <md:EmailAddress>mailto:bschlesi@uni-koeln.de</md:EmailAddress>
+    </md:ContactPerson>
+    <md:ContactPerson
+            xmlns:remd="http://refeds.org/metadata"
+            contactType="other"
+            remd:contactType="http://refeds.org/metadata/contactType/security">
+        <md:GivenName>Diensteentwicklung</md:GivenName>
+        <md:EmailAddress>mailto:diensteentwicklung-rrzk@uni-koeln.de</md:EmailAddress>
+    </md:ContactPerson>
 </md:EntityDescriptor>


### PR DESCRIPTION
We renewed the server certificate ka3.uni-koeln.de und updated the metadata xml accordingly.