### PR TITLE
change one user contactType to support to fix QA report?

### DIFF
--- a/metadata/repo.clarino.uib.no%2Fshibboleth%2Fsp.xml
+++ b/metadata/repo.clarino.uib.no%2Fshibboleth%2Fsp.xml
@@ -239,7 +239,7 @@
       <md:SurName>Gjesdal</md:SurName>
       <md:EmailAddress>mailto:oyvind.gjesdal@uib.no</md:EmailAddress>
    </md:ContactPerson>
-   <md:ContactPerson contactType="technical">
+   <md:ContactPerson contactType="support">
       <md:GivenName>Tone Merete</md:GivenName>
       <md:SurName>Bruvik</md:SurName>
       <md:EmailAddress>mailto:tone.merete.bruvik@uib.no</md:EmailAddress>


### PR DESCRIPTION
> Invalid or missing technical contact(s) under ‘md:ContactPerson[@contactType='technical']’. Please specify ‘md:GivenName’ and ‘md:SurName’ of the officially responsible person and provide a mailto URI (‘mailto:Contact.Person@organization.org’). 

I wonder if the entry marked in red in the QA report https://clarin-eric.github.io/SPF-SPs-metadata/web/sp_qa_report.html?repo.clarino.uib.no%2Fshibboleth%2Fsp_sps_qa_report_results.xml could be because of of having two `md:contactPerson contactType="technical"`, so changing back to one only, to hopefully fix (changing the other role to 'support', which was previously used, before the recent PR).

The element seems to have all the required elements and contents otherwise to me:

```
 <md:ContactPerson contactType="technical">
      <md:GivenName>Oyvind Liland</md:GivenName>
      <md:SurName>Gjesdal</md:SurName>
      <md:EmailAddress>mailto:oyvind.gjesdal@uib.no</md:EmailAddress>
   </md:ContactPerson>
```

Thank you for the merge and the nudge for following up on mail!