### PR TITLE
Add dspace.clarin.dk endpoints to repository.clarin.dk SP

### DIFF
--- a/metadata/repository.clarin.dk%2Fshibboleth.xml
+++ b/metadata/repository.clarin.dk%2Fshibboleth.xml
@@ -82,6 +82,11 @@
          <idpdisc:DiscoveryResponse Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
                                     Location="https://repository.clarin.dk/Shibboleth.sso/Login"
                                     index="1"/>
+         <init:RequestInitiator Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init"
+                                Location="https://dspace.clarin.dk/Shibboleth.sso/Login"/>
+         <idpdisc:DiscoveryResponse Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
+                                    Location="https://dspace.clarin.dk/Shibboleth.sso/Login"
+                                    index="2"/>
       </md:Extensions>
       <md:KeyDescriptor>
          <ds:KeyInfo>
@@ -151,6 +156,18 @@ b++K2ToWg8Zs3yGyMUaPxvIzw3nt
       <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS"
                                    Location="https://repository.clarin.dk/Shibboleth.sso/SAML2/ECP"
                                    index="4"/>
+      <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                                   Location="https://dspace.clarin.dk/Shibboleth.sso/SAML2/POST"
+                                   index="5"/>
+      <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign"
+                                   Location="https://dspace.clarin.dk/Shibboleth.sso/SAML2/POST-SimpleSign"
+                                   index="6"/>
+      <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact"
+                                   Location="https://dspace.clarin.dk/Shibboleth.sso/SAML2/Artifact"
+                                   index="7"/>
+      <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS"
+                                   Location="https://dspace.clarin.dk/Shibboleth.sso/SAML2/ECP"
+                                   index="8"/>
       <md:AttributeConsumingService index="1">
          <md:ServiceName xml:lang="en">CLARIN-DK-UCPH Repository</md:ServiceName>
          <md:ServiceName xml:lang="da">CLARIN-DK-UCPH repositorie</md:ServiceName>


### PR DESCRIPTION
Add additional endpoints for dspace.clarin.dk to support the new DSpace 7 installation running alongside the existing DSpace 5 at repository.clarin.dk.

Both hosts share the same entityID (https://repository.clarin.dk/shibboleth) and this update adds the necessary ACS, RequestInitiator, and DiscoveryResponse endpoints for dspace.clarin.dk.